### PR TITLE
Ignoring package-lock.json for now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 node_modules
+
+# package-lock.json
+# https://stackoverflow.com/questions/45022048/why-does-npm-install-rewrite-package-lock-json
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   "author": "Jonny Buchanan <jonathan.buchanan@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^1.3.1",
-    "eslint-config-standard": "^4.3.2",
-    "eslint-plugin-standard": "^1.3.0",
-    "tape": "^4.2.0"
+    "eslint": "~1.3.1",
+    "eslint-config-standard": "~4.3.2",
+    "eslint-plugin-standard": "~1.3.0",
+    "tape": "~4.2.0"
   },
   "dependencies": {},
   "repository": {


### PR DESCRIPTION
Also locking down our versions a little more. [ch4884]

Further (optional) reading:
https://docs.npmjs.com/files/package-lock.json
https://docs.npmjs.com/files/package-locks
npm/npm#17979
npm/npm#18103

TL;DR: There is much community debate about this file.
